### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
+[![Board Status](https://dev.azure.com/grimware/49dbd923-5dbf-4cef-95d5-222ba1818dbe/3e68e6d9-9368-481d-96ef-58035a3149c5/_apis/work/boardbadge/2c00f20b-10f9-4065-8f23-4065a2f321b7)](https://dev.azure.com/grimware/49dbd923-5dbf-4cef-95d5-222ba1818dbe/_boards/board/t/3e68e6d9-9368-481d-96ef-58035a3149c5/Microsoft.RequirementCategory)
 # Grimware.Common
 Common helper &amp; utility libraries with reusable cross-project functionality


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/grimware/49dbd923-5dbf-4cef-95d5-222ba1818dbe/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.